### PR TITLE
Adds all types of images suppted by FoundryVTT

### DIFF
--- a/image-previewer.js
+++ b/image-previewer.js
@@ -50,7 +50,7 @@ Hooks.on('renderFilePicker', (app, html, data) => {
         // get the proper image path
         let path = ev.target.dataset.path;
         let fileExtension = path.split('.')[path.split('.').length - 1].toLowerCase();
-        if (['png', 'jpg', 'svg'].includes(fileExtension)) {
+        if (CONST.IMAGE_FILE_EXTENSIONS.includes(fileExtension)) {
             imagePreviewer.showPreview(path, previewPos);
         }
     }, ev => {


### PR DESCRIPTION
Uses `CONST.IMAGE_FILE_EXTENSIONS` to support all available image types.